### PR TITLE
Fix typo in predicting from ranger; use gbm3 instead of gbm for brt

### DIFF
--- a/inst/methods/sdm/brt.R
+++ b/inst/methods/sdm/brt.R
@@ -5,7 +5,7 @@
 
 #-------------
 methodInfo <- list(name=c('brt','BRT','gbm','GBM'),
-                  packages='gbm',
+                  packages='gbm3',
                   modelTypes = c('pa','pb','ab','n'),
                   fitParams = list(formula='standard.formula',data='sdmDataFrame'),
                   fitSettings = list(distribution='bernoulli',
@@ -36,7 +36,7 @@ methodInfo <- list(name=c('brt','BRT','gbm','GBM'),
                   tuneParams = NULL,
                   predictParams=list(object='model',newdata='sdmDataFrame'),
                   predictSettings=list(n.trees=1000,type='response'),
-                  predictFunction='predict.gbm',
+                  predictFunction='predict',
                   #------ metadata (optional):
                   title='Boosted Regression Trees',
                   creator='Babak Naimi',

--- a/inst/methods/sdm/ranger.R
+++ b/inst/methods/sdm/ranger.R
@@ -23,7 +23,7 @@ methodInfo <- list(name=c('ranger','rangerRF','rangerForest'),
                    predictParams=list(object='model',data='sdmDataFrame'),
                    predictSettings=list(type='response',num.threads=1,se.method = "infjack",verbose=FALSE,seed=NULL),
                    predictFunction=function(object,data,type,num.threads,se.method,verbose,seed) {
-                     predict(object,data=data,type=type,num.threads=num.threads,verbose=verbose,seed=seed)$predictions
+                     predict(object,data=data,type=type,num.threads=num.threads,verbose=verbose,seed=seed)$predictions[,2]
                    },
                    #------ metadata (optional):
                    title='Random Forest (Ranger)',


### PR DESCRIPTION
Hello @babaknaimi,

I think this pull request fixes the following issue: https://github.com/babaknaimi/sdm/issues/35.
Further, I suggest moving to the `gbm3`  [https://github.com/gbm-developers/gbm3] for brt models, as the former `gbm` is no no longer under active development. However this is up to you to use gbm3!

Thanks,
Ahmed