### PR TITLE
Fix predicton (type = "response") for glmnet models

### DIFF
--- a/inst/methods/sdm/glmnet.R
+++ b/inst/methods/sdm/glmnet.R
@@ -28,7 +28,7 @@ methodInfo <- list(name=c('glmnet','GLMNET','glmelastic','glmlasso'),
                    predictSettings=list(type='response'),
                    predictFunction=function(object,formula,newx,type) {
                      newx <- .getData.sdmMatrix(formula,newx,normalize=TRUE)
-                     predict.glmnet(object,newx,type=type)[,1]
+                     predict(object,newx,type=type)[,1]
                    },
                    #------ metadata (optional):
                    title='GLM with lasso or elasticnet regularization',


### PR DESCRIPTION

When using `predict.glmnet` directly on a binomial `glmnet` model, specifying `type = "response"` unexpectedly returns linear predictors (log-odds) instead of probabilities (values between 0 and 1). 
Reproducible Example
```R
library(glmnet)
set.seed(123)
x <- matrix(rnorm(1000 * 5), 1000, 5)
y <- rbinom(1000, 1, 0.5)
```
```
fit <- glmnet(x, y, family = "binomial")

range(predict.glmnet(fit, x, type = "response", s = fit$lambda[1]))
# [1] -0.07603661 -0.07603661
range(predict.glmnet(fit, x, type = "link", s = fit$lambda[1]))
# [1] -0.07603661 -0.07603661

range(predict(fit, x, type = "response", s = fit$lambda[1]))
# [1] 0.481 0.481
range(predict(fit, x, type = "link", s = fit$lambda[1]))
# [1] -0.07603661 -0.07603661
```

Example using cv.glmnet model
```
fit_cv <- cv.glmnet(x, y, family = "binomial", type.measure = "auc")
fit <- glmnet(x, y, family = "binomial", lambda = fit_cv$lambda.1se)

range(predict.glmnet(fit, x, type = "response", s = fit$lambda[1]))
# [1] -0.2876808  0.2180592
range(predict.glmnet(fit, x, type = "link", s = fit$lambda[1]))
# [1] -0.2876808  0.2180592

range(predict(fit, x, type = "response", s = fit$lambda[1]))
# [1] 0.4285717 0.5542998
range(predict(fit, x, type = "link", s = fit$lambda[1]))
# [1] -0.2876808  0.2180592
```

See also [here](https://stackoverflow.com/questions/36845645). In the stackoverflow answer, it is suggested to use `predict.lognet` instead of `predict.glmnet`, but the former function is not exported from `glmnet`.

In this small fix, I suggest using the generic function `predict` instead of `predict.glmnet`.

Thanks